### PR TITLE
CORE-1796: get usage summary information from QMS.

### DIFF
--- a/clients/data_usage_api.go
+++ b/clients/data_usage_api.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -69,7 +69,7 @@ func (c *DataUsageAPI) GetUsageSummary(ctx context.Context, username string) (*U
 	}
 
 	// Read the response body.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return &usage, errors.Wrapf(err, "unable to read the response from %s", requestURL)
 	}

--- a/clients/data_usage_api.go
+++ b/clients/data_usage_api.go
@@ -52,7 +52,7 @@ func (c *DataUsageAPI) GetUsageSummary(ctx context.Context, username string) (*U
 	var usage UserDataUsage
 
 	// Build the request.
-	requestURL := c.dataUsageURL(username, "data", "current")
+	requestURL := c.dataUsageURL(StripUsernameSuffix(username), "data", "current")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
 	if err != nil {
 		return &usage, errors.Wrapf(err, "unable to build the request for %s", requestURL)

--- a/clients/data_usage_api.go
+++ b/clients/data_usage_api.go
@@ -1,0 +1,94 @@
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type DataUsageAPI struct {
+	baseURL *url.URL
+}
+
+// DataUsageAPIClient returns a new instance of DataUsageAPI for the given raw base URL.
+func DataUsageAPIClient(baseURL string) (*DataUsageAPI, error) {
+
+	//  Parse the raw base URL.
+	url, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure that the base URL path doesn't end with a slash.
+	url.Path = strings.TrimSuffix(url.Path, "/")
+
+	return &DataUsageAPI{baseURL: url}, nil
+}
+
+// UserDataUsage contains a user's current data usage, as returned by data-usage-api service.
+type UserDataUsage struct {
+	ID           string `json:"id"`
+	UserID       string `json:"user_id"`
+	Username     string `json:"username"`
+	Total        int64  `json:"total"`
+	Time         string `json:"time"`
+	LastModified string `json:"last_modified"`
+}
+
+// dataUsageURL returns a URL that can be used to connect to the data-usage-api service. The URL path is determined by
+// the base URL and the arguments.
+func (c *DataUsageAPI) dataUsageURL(components ...string) *url.URL {
+	newURL := *c.baseURL
+
+	// Escape all of the path components.
+	escapedComponents := make([]string, len(components))
+	for i, component := range components {
+		escapedComponents[i] = url.PathEscape(component)
+	}
+
+	// Add the components to the path.
+	newURL.Path = fmt.Sprintf("%s/%s", newURL.Path, strings.Join(escapedComponents, "/"))
+
+	// Return the new URL.
+	return &newURL
+}
+
+// GetUsageSummary obtains the usage summary information for a user.
+func (c *DataUsageAPI) GetUsageSummary(ctx context.Context, username string) (*UserDataUsage, error) {
+	var usage UserDataUsage
+
+	// Build the request.
+	requestURL := c.dataUsageURL(username, "data", "current")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return &usage, err
+	}
+
+	// Get the response.
+	resp, err := client.Do(req)
+	if err != nil {
+		return &usage, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return &usage, NewHTTPError(resp.StatusCode, "unexpected status code returned by service")
+	}
+	defer resp.Body.Close()
+
+	// Read the response body.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return &usage, err
+	}
+
+	// Unmarshal the response body.
+	err = json.Unmarshal(body, &usage)
+	if err != nil {
+		return &usage, err
+	}
+
+	return &usage, nil
+}

--- a/clients/main.go
+++ b/clients/main.go
@@ -1,7 +1,10 @@
 package clients
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
@@ -43,4 +46,21 @@ func GetStatusCode(e error) int {
 	} else {
 		return http.StatusInternalServerError
 	}
+}
+
+// BuildURL builds a URL from a base URL and zero or URL path components.
+func BuildURL(baseURL *url.URL, components ...string) *url.URL {
+	newURL := *baseURL
+
+	// Escape all of the path components.
+	escapedComponents := make([]string, len(components))
+	for i, component := range components {
+		escapedComponents[i] = url.PathEscape(component)
+	}
+
+	// Add the components to the path.
+	newURL.Path = fmt.Sprintf("%s/%s", newURL.Path, strings.Join(escapedComponents, "/"))
+
+	// Return the new URL.
+	return &newURL
 }

--- a/clients/main.go
+++ b/clients/main.go
@@ -1,0 +1,46 @@
+package clients
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// An HTTP client to be used by all of the client libraries.
+var client = http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+
+// HTTPError represents an error returned by an HTTP service
+type HTTPError struct {
+	statusCode int
+	message    string
+}
+
+// NewHTTPError returns a new HTTPError.
+func NewHTTPError(statusCode int, message string) *HTTPError {
+	return &HTTPError{
+		statusCode: statusCode,
+		message:    message,
+	}
+}
+
+// Error returns the error message associated with an HTTPError.
+func (e *HTTPError) Error() string {
+	return e.message
+}
+
+// StatusCode returns the status code associated with an HTTPError.
+func (e *HTTPError) StatusCode() int {
+	return e.statusCode
+}
+
+// GetStatusCode returns the appropriate status code to use for an error returned by one of the client libraries.
+// If the error happens to be an HTTP error, then the original status code is returned. Otherwise, the code defaults
+// to http.StatusInternalServerError.
+func GetStatusCode(e error) int {
+	herror, ok := e.(*HTTPError)
+	if ok {
+		return herror.StatusCode()
+	} else {
+		return http.StatusInternalServerError
+	}
+}

--- a/clients/main.go
+++ b/clients/main.go
@@ -4,10 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
+
+// A regular expression used to remove suffixes from usernames.
+var usernameSuffixRegexp = regexp.MustCompile("@.*$")
 
 // An HTTP client to be used by all of the client libraries.
 var client = http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
@@ -63,4 +67,9 @@ func BuildURL(baseURL *url.URL, components ...string) *url.URL {
 
 	// Return the new URL.
 	return &newURL
+}
+
+// StripUsernameSuffix removes the username suffix from a username.
+func StripUsernameSuffix(username string) string {
+	return usernameSuffixRegexp.ReplaceAllString(username, "")
 }

--- a/clients/qms.go
+++ b/clients/qms.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -64,7 +64,7 @@ func (c *QMSAPI) GetUserPlan(ctx context.Context, username string) (*UserPlan, e
 	}
 
 	// Read the response body.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return &upr.Result, errors.Wrapf(err, "unable to read the response from %s", requestURL)
 	}

--- a/clients/qms.go
+++ b/clients/qms.go
@@ -89,7 +89,7 @@ func (c *QMSAPI) GetUserPlan(ctx context.Context, username string) (*UserPlan, e
 	var upr UserPlanResult
 
 	// Build the request.
-	requestURL := c.qmsURL("v1", "users", username, "plan")
+	requestURL := c.qmsURL("v1", "users", StripUsernameSuffix(username), "plan")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
 	if err != nil {
 		return &upr.Result, errors.Wrapf(err, "unable to build the request for %s", requestURL)

--- a/clients/qms.go
+++ b/clients/qms.go
@@ -1,0 +1,121 @@
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// QMSAPI represents an instance of a QMS API client.
+type QMSAPI struct {
+	baseURL *url.URL
+}
+
+// QMSAPIClient returns a new QMSAPI instance.
+func QMSAPIClient(baseURL string) (*QMSAPI, error) {
+
+	//  Parse the raw base URL.
+	url, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure that the base URL path doesn't end with a slash.
+	url.Path = strings.TrimSuffix(url.Path, "/")
+
+	return &QMSAPI{baseURL: url}, nil
+}
+
+// User is the QMS representation of a user.
+type User struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+}
+
+// Plan is the representation of a plan.
+type Plan struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type ResourceType struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Unit string `json:"description"`
+}
+
+type Quota struct {
+	ID           string       `json:"id"`
+	Quota        float64      `json:"quota"`
+	ResourceType ResourceType `json:"resource_type"`
+}
+
+type Usage struct {
+	ID           string       `json:"id"`
+	Usage        float64      `json:"usage"`
+	ResourceType ResourceType `json:"resource_type"`
+}
+
+// UserPlan is the representation of a user plan.
+type UserPlan struct {
+	ID                 string  `json:"id"`
+	EffectiveStartDate string  `json:"effective_start_date"`
+	EffectiveEndDate   string  `json:"effective_end_date"`
+	User               User    `json:"users"`
+	Plan               Plan    `json:"plan"`
+	Quotas             []Quota `json:"quotas"`
+	Usages             []Usage `json:"-"`
+}
+
+type UserPlanResult struct {
+	Result UserPlan `json:"result"`
+}
+
+// qmsURL returns a URL that can be used to connect to QMS. The URL path is determined by the base URL and the path
+// components in the argument list.
+func (c QMSAPI) qmsURL(components ...string) *url.URL {
+	return BuildURL(c.baseURL, components...)
+}
+
+// GetUserPlan retrieves the subscription information for the given user.
+func (c *QMSAPI) GetUserPlan(ctx context.Context, username string) (*UserPlan, error) {
+	var upr UserPlanResult
+
+	// Build the request.
+	requestURL := c.qmsURL("v1", "users", username, "plan")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return &upr.Result, errors.Wrapf(err, "unable to build the request for %s", requestURL)
+	}
+
+	// Get the response.
+	resp, err := client.Do(req)
+	if err != nil {
+		return &upr.Result, errors.Wrapf(err, "unable to send the request to %s", requestURL)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return &upr.Result, NewHTTPError(resp.StatusCode, fmt.Sprintf("%s returned %d", requestURL, resp.StatusCode))
+	}
+
+	// Read the response body.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return &upr.Result, errors.Wrapf(err, "unable to read the response from %s", requestURL)
+	}
+
+	// Unmarshal the response body.
+	err = json.Unmarshal(body, &upr)
+	if err != nil {
+		return &upr.Result, errors.Wrapf(err, "unable to parse the response from %s", requestURL)
+	}
+
+	return &upr.Result, nil
+}

--- a/clients/qms.go
+++ b/clients/qms.go
@@ -32,48 +32,6 @@ func QMSAPIClient(baseURL string) (*QMSAPI, error) {
 	return &QMSAPI{baseURL: url}, nil
 }
 
-// User is the QMS representation of a user.
-type User struct {
-	ID       string `json:"id"`
-	Username string `json:"username"`
-}
-
-// Plan is the representation of a plan.
-type Plan struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
-
-type ResourceType struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Unit string `json:"description"`
-}
-
-type Quota struct {
-	ID           string       `json:"id"`
-	Quota        float64      `json:"quota"`
-	ResourceType ResourceType `json:"resource_type"`
-}
-
-type Usage struct {
-	ID           string       `json:"id"`
-	Usage        float64      `json:"usage"`
-	ResourceType ResourceType `json:"resource_type"`
-}
-
-// UserPlan is the representation of a user plan.
-type UserPlan struct {
-	ID                 string  `json:"id"`
-	EffectiveStartDate string  `json:"effective_start_date"`
-	EffectiveEndDate   string  `json:"effective_end_date"`
-	User               User    `json:"users"`
-	Plan               Plan    `json:"plan"`
-	Quotas             []Quota `json:"quotas"`
-	Usages             []Usage `json:"-"`
-}
-
 type UserPlanResult struct {
 	Result UserPlan `json:"result"`
 }

--- a/clients/user_plan.go
+++ b/clients/user_plan.go
@@ -1,0 +1,64 @@
+package clients
+
+import "time"
+
+// User is the QMS representation of a user.
+type User struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+}
+
+// Plan is the representation of a plan.
+type Plan struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type ResourceType struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Unit string `json:"description"`
+}
+
+type Quota struct {
+	ID           string       `json:"id"`
+	Quota        float64      `json:"quota"`
+	ResourceType ResourceType `json:"resource_type"`
+}
+
+type Usage struct {
+	ID           string       `json:"id"`
+	Usage        float64      `json:"usage"`
+	ResourceType ResourceType `json:"resource_type"`
+}
+
+// UserPlan is the representation of a user plan.
+type UserPlan struct {
+	ID                 string    `json:"id"`
+	EffectiveStartDate time.Time `json:"effective_start_date"`
+	EffectiveEndDate   time.Time `json:"effective_end_date"`
+	User               User      `json:"users"`
+	Plan               Plan      `json:"plan"`
+	Quotas             []Quota   `json:"quotas"`
+	Usages             []Usage   `json:"usages"`
+}
+
+// Resource type name constants.
+const (
+	ResourceTypeCPUHours = "cpu.hours"
+	ResourceTypeDataSize = "data.size"
+)
+
+// ExtractUsage extracts the usage record for a given resource type from the user plan.
+func (up *UserPlan) ExtractUsage(resourceType string) *Usage {
+
+	// Search for the usage record matching the givn resource type.
+	for _, usageRecord := range up.Usages {
+		if usageRecord.ResourceType.Name == resourceType {
+			return &usageRecord
+		}
+	}
+
+	return nil
+}

--- a/internal/summarizer/default.go
+++ b/internal/summarizer/default.go
@@ -1,0 +1,103 @@
+package summarizer
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+
+	"github.com/cyverse-de/resource-usage-api/clients"
+	"github.com/cyverse-de/resource-usage-api/db"
+	"github.com/jmoiron/sqlx"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+)
+
+type DefaultSummarizer struct {
+	Context         context.Context
+	Log             *logrus.Entry
+	User            string
+	OTelName        string
+	Database        *sqlx.DB
+	DataUsageClient *clients.DataUsageAPI
+}
+
+// loadCPUUsage loads the user's CPU usage information from the DE database.
+func (d *DefaultSummarizer) loadCPUUsage(summary *UserSummary) {
+
+	// Start an OpenTelemetry span.
+	ctx, span := otel.Tracer(d.OTelName).Start(d.Context, "summary: CPU hours")
+
+	// Establish the database connection.
+	database := db.New(d.Database)
+
+	// Load the CPU usage information from the database.
+	cpuHours, err := database.CurrentCPUHoursForUser(ctx, d.User)
+	if err == sql.ErrNoRows {
+		cpuHours = &db.CPUHours{}
+		summary.Errors = append(
+			summary.Errors,
+			APIError{
+				Field:     "cpu_usage",
+				Message:   "no current CPU hours found for user",
+				ErrorCode: http.StatusNotFound,
+			},
+		)
+	} else if err != nil {
+		d.Log.WithContext(ctx).Error(err)
+		cpuHours = &db.CPUHours{}
+		summary.Errors = append(
+			summary.Errors,
+			APIError{
+				Field:     "cpu_usage",
+				Message:   err.Error(),
+				ErrorCode: http.StatusInternalServerError,
+			},
+		)
+	}
+
+	// Save the CPU usage information in the summary.
+	summary.CPUUsage = cpuHours
+
+	// Close the OpenTelemetry span.
+	span.End()
+}
+
+// loadDataUsage loads the user's data store usage information from data-usage-api.
+func (d DefaultSummarizer) loadDataUsage(summary *UserSummary) {
+
+	// Start an OpenTelemetry span.
+	ctx, span := otel.Tracer(d.OTelName).Start(d.Context, "summary: data usage")
+
+	// Obtain the data store usage information.
+	usage, err := d.DataUsageClient.GetUsageSummary(ctx, d.User)
+	if err != nil {
+		d.Log.WithContext(ctx).Error(err)
+		summary.Errors = append(
+			summary.Errors,
+			APIError{
+				Field:     "data_usage",
+				Message:   err.Error(),
+				ErrorCode: clients.GetStatusCode(err),
+			},
+		)
+	}
+
+	// Save the Data usage information in the summary.
+	summary.DataUsage = usage
+
+	// Close the OpenTelemetry span.
+	span.End()
+}
+
+// LoadSummary aggregates and summarizes the user's resource usage information.
+func (d *DefaultSummarizer) LoadSummary() *UserSummary {
+	var summary UserSummary
+
+	// Load the CPU usage information.
+	d.loadCPUUsage(&summary)
+
+	// Load the data usage information.
+	d.loadDataUsage(&summary)
+
+	return &summary
+}

--- a/internal/summarizer/main.go
+++ b/internal/summarizer/main.go
@@ -11,6 +11,15 @@ type APIError struct {
 	ErrorCode int    `json:"error_code"`
 }
 
+// NewAPIError is a simple convenience function for generating a new API error struct.
+func NewAPIError(field string, message string, errorCode int) *APIError {
+	return &APIError{
+		Field:     field,
+		Message:   message,
+		ErrorCode: errorCode,
+	}
+}
+
 // UserSummary contains the data summarizing the user's current resource
 // usages and their current plan.
 type UserSummary struct {

--- a/internal/summarizer/main.go
+++ b/internal/summarizer/main.go
@@ -1,0 +1,72 @@
+package summarizer
+
+import (
+	"github.com/cyverse-de/resource-usage-api/clients"
+	"github.com/cyverse-de/resource-usage-api/db"
+)
+
+// User is the QMS representation of a user.
+type User struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+}
+
+// Plan is the representation of a plan.
+type Plan struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type ResourceType struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Unit string `json:"description"`
+}
+
+type Quota struct {
+	ID           string       `json:"id"`
+	Quota        float64      `json:"quota"`
+	ResourceType ResourceType `json:"resource_type"`
+}
+
+type Usage struct {
+	ID           string       `json:"id"`
+	Usage        float64      `json:"usage"`
+	ResourceType ResourceType `json:"resource_type"`
+}
+
+// UserPlan is the representation of a user plan.
+type UserPlan struct {
+	ID                 string  `json:"id"`
+	EffectiveStartDate string  `json:"effective_start_date"`
+	EffectiveEndDate   string  `json:"effective_end_date"`
+	User               User    `json:"users"`
+	Plan               Plan    `json:"plan"`
+	Quotas             []Quota `json:"quotas"`
+	Usages             []Usage `json:"-"`
+}
+
+type UserPlanResult struct {
+	Result UserPlan `json:"result"`
+}
+
+type APIError struct {
+	Field     string `json:"field"`
+	Message   string `json:"message"`
+	ErrorCode int    `json:"error_code"`
+}
+
+// UserSummary contains the data summarizing the user's current resource
+// usages and their current plan.
+type UserSummary struct {
+	CPUUsage  *db.CPUHours           `json:"cpu_usage"`
+	DataUsage *clients.UserDataUsage `json:"data_usage"`
+	UserPlan  *UserPlan              `json:"user_plan"`
+	Errors    []APIError             `json:"errors"`
+}
+
+// The interface used to load the usage summary information.
+type Summarizer interface {
+	LoadSummary() *UserSummary
+}

--- a/internal/summarizer/main.go
+++ b/internal/summarizer/main.go
@@ -5,52 +5,6 @@ import (
 	"github.com/cyverse-de/resource-usage-api/db"
 )
 
-// User is the QMS representation of a user.
-type User struct {
-	ID       string `json:"id"`
-	Username string `json:"username"`
-}
-
-// Plan is the representation of a plan.
-type Plan struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
-
-type ResourceType struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Unit string `json:"description"`
-}
-
-type Quota struct {
-	ID           string       `json:"id"`
-	Quota        float64      `json:"quota"`
-	ResourceType ResourceType `json:"resource_type"`
-}
-
-type Usage struct {
-	ID           string       `json:"id"`
-	Usage        float64      `json:"usage"`
-	ResourceType ResourceType `json:"resource_type"`
-}
-
-// UserPlan is the representation of a user plan.
-type UserPlan struct {
-	ID                 string  `json:"id"`
-	EffectiveStartDate string  `json:"effective_start_date"`
-	EffectiveEndDate   string  `json:"effective_end_date"`
-	User               User    `json:"users"`
-	Plan               Plan    `json:"plan"`
-	Quotas             []Quota `json:"quotas"`
-	Usages             []Usage `json:"-"`
-}
-
-type UserPlanResult struct {
-	Result UserPlan `json:"result"`
-}
-
 type APIError struct {
 	Field     string `json:"field"`
 	Message   string `json:"message"`
@@ -62,7 +16,7 @@ type APIError struct {
 type UserSummary struct {
 	CPUUsage  *db.CPUHours           `json:"cpu_usage"`
 	DataUsage *clients.UserDataUsage `json:"data_usage"`
-	UserPlan  *UserPlan              `json:"user_plan"`
+	UserPlan  *clients.UserPlan      `json:"user_plan"`
 	Errors    []APIError             `json:"errors"`
 }
 

--- a/internal/summarizer/qms.go
+++ b/internal/summarizer/qms.go
@@ -1,0 +1,138 @@
+package summarizer
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+
+	"github.com/cyverse-de/resource-usage-api/clients"
+	"github.com/cyverse-de/resource-usage-api/db"
+	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+)
+
+type QMSSummarizer struct {
+	Context   context.Context
+	Log       *logrus.Entry
+	User      string
+	OTelName  string
+	Database  *sqlx.DB
+	QMSClient *clients.QMSAPI
+}
+
+// loadUserID looks up the user ID in the DE database and adds it to the summary
+func (s *QMSSummarizer) loadUserID(summary *UserSummary) string {
+
+	// Start an OpenTelemetry span.
+	ctx, span := otel.Tracer(s.OTelName).Start(s.Context, "summary: user ID")
+
+	// Look up the user ID.
+	database := db.New(s.Database)
+	userID, err := database.UserID(ctx, s.User)
+	if err == sql.ErrNoRows {
+		err = errors.Wrapf(err, "user %s not found", s.User)
+		s.Log.WithContext(ctx).Error(err)
+		summary.Errors = append(
+			summary.Errors,
+			*NewAPIError("cpu_usage", err.Error(), http.StatusNotFound),
+			*NewAPIError("data_usage", err.Error(), http.StatusNotFound),
+		)
+	} else if err != nil {
+		err = errors.Wrapf(err, "unable to look up the user ID for %s", s.User)
+		s.Log.WithContext(ctx).Error(err)
+		summary.Errors = append(
+			summary.Errors,
+			*NewAPIError("cpu_usage", err.Error(), http.StatusInternalServerError),
+			*NewAPIError("data_usage", err.Error(), http.StatusInternalServerError),
+		)
+	}
+
+	// Store the username and User ID; the user ID will be empty if an error occurred.
+	summary.CPUUsage.Username = s.User
+	summary.CPUUsage.UserID = userID
+	summary.DataUsage.Username = s.User
+	summary.DataUsage.UserID = userID
+
+	// Close the OpenTelemetry span.
+	span.End()
+
+	return userID
+}
+
+// loadUserPlan retrieves the user's subscription plan information from QMS.
+func (s *QMSSummarizer) loadUserPlan(summary *UserSummary) {
+
+	// Start an OpenTelemetry span.
+	ctx, span := otel.Tracer(s.OTelName).Start(s.Context, "summary: user plan")
+
+	// Obtain the user plan information.
+	userPlan, err := s.QMSClient.GetUserPlan(ctx, s.User)
+	if err != nil {
+		s.Log.WithContext(ctx).Error(err)
+		summary.Errors = append(
+			summary.Errors,
+			*NewAPIError("user_plan", err.Error(), clients.GetStatusCode(err)),
+		)
+	}
+
+	// Save the user plan information in the summary.
+	summary.UserPlan = userPlan
+
+	// Add the CPU usage to the summary.
+	cpuUsage := userPlan.ExtractUsage(clients.ResourceTypeCPUHours)
+	if cpuUsage != nil {
+		summary.CPUUsage.ID = cpuUsage.ID
+		summary.CPUUsage.EffectiveEnd = userPlan.EffectiveEndDate
+		summary.CPUUsage.EffectiveStart = userPlan.EffectiveStartDate
+		_, err = summary.CPUUsage.Total.SetFloat64(cpuUsage.Usage)
+		if err != nil {
+			err = errors.Wrap(err, "unable to set the CPU usage total")
+			summary.Errors = append(
+				summary.Errors,
+				*NewAPIError("cpu_usage", err.Error(), http.StatusInternalServerError),
+			)
+		}
+	} else {
+		msg := fmt.Sprintf("no current CPU hours found for %s", s.User)
+		summary.Errors = append(
+			summary.Errors,
+			*NewAPIError("cpu_usage", msg, http.StatusNotFound),
+		)
+	}
+
+	// Add the data usage to the summary.
+	dataUsage := userPlan.ExtractUsage(clients.ResourceTypeDataSize)
+	if dataUsage != nil {
+		summary.DataUsage.ID = dataUsage.ID
+		summary.DataUsage.Total = int64(dataUsage.Usage)
+	} else {
+		msg := fmt.Sprintf("no data usage found for %s", s.User)
+		summary.Errors = append(
+			summary.Errors,
+			*NewAPIError("data_usage", msg, http.StatusNotFound),
+		)
+	}
+
+	// Close the OpenTelemetry span.
+	span.End()
+}
+
+// LoadSummary aggregates and summarizes the user's resource usage information.
+func (s *QMSSummarizer) LoadSummary() *UserSummary {
+	var summary UserSummary
+
+	// Add empty usage records to the summary information.
+	summary.CPUUsage = &db.CPUHours{}
+	summary.DataUsage = &clients.UserDataUsage{}
+
+	// Look up the user ID in the database.
+	s.loadUserID(&summary)
+
+	// Load the user plan information from QMS.
+	s.loadUserPlan(&summary)
+
+	return &summary
+}

--- a/internal/summary.go
+++ b/internal/summary.go
@@ -1,19 +1,11 @@
 package internal
 
 import (
-	"database/sql"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"strings"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel"
 
-	"github.com/cyverse-de/resource-usage-api/db"
+	"github.com/cyverse-de/resource-usage-api/internal/summarizer"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
 )
@@ -22,318 +14,25 @@ var client = http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)
 
 const otelName = "github.com/cyverse-de/resource-usage-api/internal"
 
-// UserDataUsage contains a user's current data usage, as returned by the
-// data-usage-api service.
-type UserDataUsage struct {
-	ID           string `json:"id"`
-	UserID       string `json:"user_id"`
-	Username     string `json:"username"`
-	Total        int64  `json:"total"`
-	Time         string `json:"time"`
-	LastModified string `json:"last_modified"`
-}
-
-// User is the QMS representation of a user.
-type User struct {
-	ID       string `json:"id"`
-	Username string `json:"username"`
-}
-
-// Plan is the representation of a plan.
-type Plan struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
-
-type ResourceType struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Unit string `json:"description"`
-}
-
-type Quota struct {
-	ID           string       `json:"id"`
-	Quota        float64      `json:"quota"`
-	ResourceType ResourceType `json:"resource_type"`
-}
-
-type Usage struct {
-	ID           string       `json:"id"`
-	Usage        float64      `json:"usage"`
-	ResourceType ResourceType `json:"resource_type"`
-}
-
-// UserPlan is the representation of a user plan.
-type UserPlan struct {
-	ID                 string  `json:"id"`
-	EffectiveStartDate string  `json:"effective_start_date"`
-	EffectiveEndDate   string  `json:"effective_end_date"`
-	User               User    `json:"users"`
-	Plan               Plan    `json:"plan"`
-	Quotas             []Quota `json:"quotas"`
-	Usages             []Usage `json:"-"`
-}
-
-type UserPlanResult struct {
-	Result UserPlan `json:"result"`
-}
-
-type APIError struct {
-	Field     string `json:"field"`
-	Message   string `json:"message"`
-	ErrorCode int    `json:"error_code"`
-}
-
-// UserSummary contains the data summarizing the user's current resource
-// usages and their current plan.
-type UserSummary struct {
-	CPUUsage  *db.CPUHours   `json:"cpu_usage"`
-	DataUsage *UserDataUsage `json:"data_usage"`
-	UserPlan  *UserPlan      `json:"user_plan"`
-	Errors    []APIError     `json:"errors"`
-}
-
 // GetUserSummary is an echo request handler for requests to get a user's
 // resource usage and current plan (if QMS is enabled).
 func (a *App) GetUserSummary(c echo.Context) error {
-	var (
-		err     error
-		summary UserSummary
-
-		duOK   bool
-		planOK bool
-
-		userPlanReq  *http.Request
-		userPlanResp *http.Response
-		userPlanBody []byte
-
-		dataUsageReq *http.Request
-		duResp       *http.Response
-		duBody       []byte
-	)
-	duOK = true
-	planOK = true
-
 	context := c.Request().Context()
-
 	user := c.Param("username")
-	if user == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, errors.New("username was not set"))
-	}
-	user = a.FixUsername(user)
+	log := log.WithFields(logrus.Fields{"context": "get user summary", "user": user}).WithContext(context)
 
-	log = log.WithFields(logrus.Fields{"context": "get user summary", "user": user}).WithContext(context)
-
-	cpuCtx, cpuSpan := otel.Tracer(otelName).Start(context, "summary: CPU hours")
-
-	d := db.New(a.database)
-
-	var cpuHours *db.CPUHours
-
-	cpuHours, err = d.CurrentCPUHoursForUser(cpuCtx, user)
-	if err == sql.ErrNoRows {
-		cpuHours = &db.CPUHours{}
-		cpuHoursError := APIError{
-			Field:     "cpu_usage",
-			Message:   "no current CPU hours found for user",
-			ErrorCode: http.StatusNotFound,
-		}
-		summary.Errors = append(summary.Errors, cpuHoursError)
-	} else if err != nil {
-		log.WithContext(cpuCtx).Error(err)
-		cpuHours = &db.CPUHours{}
-		cpuHoursError := APIError{
-			Field:     "cpu_usage",
-			Message:   err.Error(),
-			ErrorCode: http.StatusInternalServerError,
-		}
-		summary.Errors = append(summary.Errors, cpuHoursError)
-	}
-	cpuSpan.End()
-
-	dataUsageCtx, dataUsageSpan := otel.Tracer(otelName).Start(context, "summary: data usage")
-	// Put together the URL for the request in to the data-usage-api
-	dataUsageURL, err := url.Parse(a.dataUsageBase)
-	if err != nil {
-		duOK = false
-		duError := APIError{
-			Field:     "data_usage",
-			Message:   err.Error(),
-			ErrorCode: http.StatusInternalServerError,
-		}
-		summary.Errors = append(summary.Errors, duError)
+	// Create the summarizer instance.
+	summarizer := &summarizer.DefaultSummarizer{
+		Context:         c.Request().Context(),
+		Log:             log,
+		User:            user,
+		OTelName:        otelName,
+		Database:        a.database,
+		DataUsageClient: a.dataUsageClient,
+		QMSClient:       a.qmsClient,
 	}
 
-	if duOK {
-		// The path should be /:username/data/current,
-		dataUsageURL.Path = fmt.Sprintf("/%s%s", user, a.dataUsageCurrent)
-
-		// Create the request to to the data-usage-api.
-		dataUsageReq, err = http.NewRequestWithContext(dataUsageCtx, http.MethodGet, dataUsageURL.String(), nil)
-		if err != nil {
-			duOK = false
-			duError := APIError{
-				Field:     "data_usage",
-				Message:   err.Error(),
-				ErrorCode: http.StatusInternalServerError,
-			}
-			summary.Errors = append(summary.Errors, duError)
-		}
-	}
-
-	if duOK {
-		// Make the request to the data-usage-api. Close the body when the handler returns.
-		duResp, err = client.Do(dataUsageReq)
-		if err != nil {
-			duOK = false
-			duError := APIError{
-				Field:     "data_usage",
-				Message:   err.Error(),
-				ErrorCode: http.StatusInternalServerError,
-			}
-			summary.Errors = append(summary.Errors, duError)
-		} else if duResp.StatusCode < 200 || duResp.StatusCode > 299 {
-			duOK = false
-			duError := APIError{
-				Field:     "data_usage",
-				Message:   fmt.Sprintf("status code was %d", duResp.StatusCode),
-				ErrorCode: duResp.StatusCode,
-			}
-			summary.Errors = append(summary.Errors, duError)
-		}
-		defer duResp.Body.Close()
-	}
-
-	if duOK {
-		// Read the body and parse the JSON into a struct.
-		duBody, err = io.ReadAll(duResp.Body)
-		if err != nil {
-			duOK = false
-			duError := APIError{
-				Field:     "data_usage",
-				Message:   err.Error(),
-				ErrorCode: http.StatusInternalServerError,
-			}
-			summary.Errors = append(summary.Errors, duError)
-		}
-	}
-
-	var du UserDataUsage
-
-	if duOK {
-		if err = json.Unmarshal(duBody, &du); err != nil {
-			duError := APIError{
-				Field:     "data_usage",
-				Message:   err.Error(),
-				ErrorCode: http.StatusInternalServerError,
-			}
-			summary.Errors = append(summary.Errors, duError)
-		}
-	}
-	dataUsageSpan.End()
-
-	if a.qmsEnabled {
-		userPlanCtx, userPlanSpan := otel.Tracer(otelName).Start(context, "summary: user plan")
-		// Get the user plan
-		userPlanURL, err := url.Parse(a.qmsBaseURL)
-		if err != nil {
-			planOK = false
-			planErr := APIError{
-				Field:     "user_plan",
-				Message:   err.Error(),
-				ErrorCode: http.StatusInternalServerError,
-			}
-			summary.Errors = append(summary.Errors, planErr)
-		}
-		userPlanURL.Path = fmt.Sprintf(
-			"/v1/users/%s/plan",
-			strings.TrimSuffix(user, fmt.Sprintf("@%s", a.userSuffix)),
-		)
-
-		log.Debug(userPlanURL.String())
-
-		if planOK {
-			userPlanReq, err = http.NewRequestWithContext(userPlanCtx, http.MethodGet, userPlanURL.String(), nil)
-			if err != nil {
-				planOK = false
-				planErr := APIError{
-					Field:     "user_plan",
-					Message:   err.Error(),
-					ErrorCode: http.StatusInternalServerError,
-				}
-				summary.Errors = append(summary.Errors, planErr)
-			}
-		}
-
-		if planOK {
-			userPlanResp, err = client.Do(userPlanReq)
-			if err != nil {
-				planOK = false
-				planErr := APIError{
-					Field:     "user_plan",
-					Message:   err.Error(),
-					ErrorCode: http.StatusInternalServerError,
-				}
-				summary.Errors = append(summary.Errors, planErr)
-				if userPlanResp.Body != nil {
-					userPlanResp.Body.Close()
-				}
-			} else if userPlanResp.StatusCode < 200 || userPlanResp.StatusCode > 299 {
-				planOK = false
-				planErr := APIError{
-					Field:     "user_plan",
-					Message:   fmt.Sprintf("status code was %d", userPlanResp.StatusCode),
-					ErrorCode: userPlanResp.StatusCode,
-				}
-				summary.Errors = append(summary.Errors, planErr)
-				if userPlanResp.Body != nil {
-					userPlanResp.Body.Close()
-				}
-			}
-		}
-
-		if planOK {
-			// Read the body and parse the JSON into a struct.
-			userPlanBody, err = io.ReadAll(userPlanResp.Body)
-			if err != nil {
-				planOK = false
-				planErr := APIError{
-					Field:     "user_plan",
-					Message:   err.Error(),
-					ErrorCode: http.StatusInternalServerError,
-				}
-				summary.Errors = append(summary.Errors, planErr)
-			}
-		}
-
-		var up UserPlanResult
-
-		if planOK {
-			if err = json.Unmarshal(userPlanBody, &up); err != nil {
-				planErr := APIError{
-					Field:     "user_plan",
-					Message:   err.Error(),
-					ErrorCode: http.StatusInternalServerError,
-				}
-				summary.Errors = append(summary.Errors, planErr)
-			}
-		}
-
-		summary.UserPlan = &up.Result
-		userPlanSpan.End()
-	} else {
-		summary.UserPlan = &UserPlan{}
-		summary.Errors = append(summary.Errors, APIError{
-			Field:     "user_plan",
-			Message:   "QMS support is disabled",
-			ErrorCode: http.StatusInternalServerError,
-		})
-	}
-
-	summary.CPUUsage = cpuHours
-	summary.DataUsage = &du
-
+	// Obtain the summary and send it to the caller.
+	summary := summarizer.LoadSummary()
 	return c.JSON(http.StatusOK, &summary)
-
 }

--- a/internal/summary.go
+++ b/internal/summary.go
@@ -25,7 +25,7 @@ func (a *App) GetUserSummary(c echo.Context) error {
 	summarizer := &summarizer.DefaultSummarizer{
 		Context:         c.Request().Context(),
 		Log:             log,
-		User:            user,
+		User:            a.FixUsername(user),
 		OTelName:        otelName,
 		Database:        a.database,
 		DataUsageClient: a.dataUsageClient,

--- a/main.go
+++ b/main.go
@@ -89,7 +89,6 @@ func main() {
 		newUserTotalIntervalFlag = flag.String("new-user-total-interval", "365", "The number of days that user gets for new CPU hours tracking. Must parse as an integer.")
 		usageRoutingKey          = flag.String("usage-routing-key", "qms.usages", "The routing key to use when sending usage updates over AMQP")
 		dataUsageBase            = flag.String("data-usage-base-url", "http://data-usage-api", "The base URL for contacting the data-usage-api service")
-		dataUsageCurrentSuffix   = flag.String("data-usage-current-suffix", "/data/current", "The data-usage-api endpoints start with /:username, so this is the rest of the path after that.")
 	)
 
 	flag.Parse()
@@ -269,17 +268,19 @@ func main() {
 	}
 
 	appConfig := &internal.AppConfiguration{
-		UserSuffix:               userSuffix,
-		DataUsageBaseURL:         *dataUsageBase,
-		CurrentDataUsageEndpoint: *dataUsageCurrentSuffix,
-		AMQPClient:               amqpClient,
-		NATSClient:               natsClient,
-		AMQPUsageRoutingKey:      *usageRoutingKey,
-		QMSEnabled:               qmsEnabled,
-		QMSBaseURL:               qmsBaseURL,
+		UserSuffix:          userSuffix,
+		DataUsageBaseURL:    *dataUsageBase,
+		AMQPClient:          amqpClient,
+		NATSClient:          natsClient,
+		AMQPUsageRoutingKey: *usageRoutingKey,
+		QMSEnabled:          qmsEnabled,
+		QMSBaseURL:          qmsBaseURL,
 	}
 
-	app := internal.New(dbconn, appConfig)
+	app, err := internal.New(dbconn, appConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	workerConfig := worker.Config{
 		Name:                    strings.ReplaceAll(uuid.New().String(), "-", ""),

--- a/main.go
+++ b/main.go
@@ -246,7 +246,9 @@ func main() {
 		nats.MaxReconnects(*maxReconnects),
 		nats.ReconnectWait(time.Duration(*reconnectWait)*time.Second),
 		nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
-			log.Errorf("disconnected from nats: %s", err.Error())
+			if err != nil {
+				log.Errorf("disconnected from nats: %s", err.Error())
+			}
 		}),
 		nats.ReconnectHandler(func(nc *nats.Conn) {
 			log.Infof("reconnected to %s", nc.ConnectedUrl())


### PR DESCRIPTION
The purpose of this change is to update the summary endpoint in `resource-udage-api` so that it obtains the resource usage information from QMS whenever QMS is enabled. Doing this will allow the DE to obtain the correct CPU usage totals when a user purchases a new subscription.
