### PR TITLE
CORE-1839: Rename the user_plans table to subscriptions

### DIFF
--- a/clients/qms.go
+++ b/clients/qms.go
@@ -32,8 +32,8 @@ func QMSAPIClient(baseURL string) (*QMSAPI, error) {
 	return &QMSAPI{baseURL: url}, nil
 }
 
-type UserPlanResult struct {
-	Result UserPlan `json:"result"`
+type SubscriptionResult struct {
+	Result Subscription `json:"result"`
 }
 
 // qmsURL returns a URL that can be used to connect to QMS. The URL path is determined by the base URL and the path
@@ -42,9 +42,9 @@ func (c QMSAPI) qmsURL(components ...string) *url.URL {
 	return BuildURL(c.baseURL, components...)
 }
 
-// GetUserPlan retrieves the subscription information for the given user.
-func (c *QMSAPI) GetUserPlan(ctx context.Context, username string) (*UserPlan, error) {
-	var upr UserPlanResult
+// GetSubscription retrieves the subscription information for the given user.
+func (c *QMSAPI) GetSubscription(ctx context.Context, username string) (*Subscription, error) {
+	var upr SubscriptionResult
 
 	// Build the request.
 	requestURL := c.qmsURL("v1", "users", StripUsernameSuffix(username), "plan")

--- a/clients/subscription.go
+++ b/clients/subscription.go
@@ -53,10 +53,10 @@ const (
 )
 
 // ExtractUsage extracts the usage record for a given resource type from the user plan.
-func (up *Subscription) ExtractUsage(resourceType string) *Usage {
+func (s *Subscription) ExtractUsage(resourceType string) *Usage {
 
 	// Search for the usage record matching the givn resource type.
-	for _, usageRecord := range up.Usages {
+	for _, usageRecord := range s.Usages {
 		if usageRecord.ResourceType.Name == resourceType {
 			return &usageRecord
 		}

--- a/clients/user_plan.go
+++ b/clients/user_plan.go
@@ -35,8 +35,8 @@ type Usage struct {
 	LastModifiedAt *time.Time   `json:"last_modified_at"`
 }
 
-// UserPlan is the representation of a user plan.
-type UserPlan struct {
+// Subscription is the representation of a user plan.
+type Subscription struct {
 	ID                 string    `json:"id"`
 	EffectiveStartDate time.Time `json:"effective_start_date"`
 	EffectiveEndDate   time.Time `json:"effective_end_date"`
@@ -53,7 +53,7 @@ const (
 )
 
 // ExtractUsage extracts the usage record for a given resource type from the user plan.
-func (up *UserPlan) ExtractUsage(resourceType string) *Usage {
+func (up *Subscription) ExtractUsage(resourceType string) *Usage {
 
 	// Search for the usage record matching the givn resource type.
 	for _, usageRecord := range up.Usages {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cyverse-de/go-mod/otelutils v0.0.2
 	github.com/cyverse-de/go-mod/pbinit v0.1.0
 	github.com/cyverse-de/go-mod/protobufjson v0.0.3
-	github.com/cyverse-de/go-mod/subjects v0.0.6
+	github.com/cyverse-de/go-mod/subjects v0.1.0
 	github.com/cyverse-de/messaging/v9 v9.1.4
 	github.com/cyverse-de/p/go/qms v0.1.0
 	github.com/guregu/null v4.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/cyverse-de/go-mod/cfg v0.0.1
 	github.com/cyverse-de/go-mod/gotelnats v0.0.11
 	github.com/cyverse-de/go-mod/otelutils v0.0.2
-	github.com/cyverse-de/go-mod/pbinit v0.0.15
+	github.com/cyverse-de/go-mod/pbinit v0.1.0
 	github.com/cyverse-de/go-mod/protobufjson v0.0.3
 	github.com/cyverse-de/go-mod/subjects v0.0.6
 	github.com/cyverse-de/messaging/v9 v9.1.4
-	github.com/cyverse-de/p/go/qms v0.0.19
+	github.com/cyverse-de/p/go/qms v0.1.0
 	github.com/guregu/null v4.0.0+incompatible
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/knadh/koanf v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/cyverse-de/go-mod/pbinit v0.0.11 h1:y/SkGwYJBkLBfNrjNilqyLsgpJiu9mvI4
 github.com/cyverse-de/go-mod/pbinit v0.0.11/go.mod h1:LQum+1DVzEtQhOila6gZEB6AcUePLalvvqWTpdXt+lA=
 github.com/cyverse-de/go-mod/pbinit v0.0.15 h1:AVy9Te4DS/vzyV0WkrnQ1VfWkFtGXLlrDhce841nMLk=
 github.com/cyverse-de/go-mod/pbinit v0.0.15/go.mod h1:olSiblycPLTy4IFu3hnmHjZG0CkB2Uk02ldXfv3wea4=
+github.com/cyverse-de/go-mod/pbinit v0.1.0 h1:XtP5JECr5bi4i0xIR4W2UQOJJGQAfS2LNI9rebHKI98=
+github.com/cyverse-de/go-mod/pbinit v0.1.0/go.mod h1:9JN/oBPmtdxepTHUbYsjEWUxdfXDDnuY1dbSH9zO6es=
 github.com/cyverse-de/go-mod/protobufjson v0.0.3 h1:XTIZejY7EUbpF6ZdhRhiFX9PGYDkGGmPP760cDswGWM=
 github.com/cyverse-de/go-mod/protobufjson v0.0.3/go.mod h1:p/ASemjpl2GEFYb3Tt7N8RozViwonsK0fOm0LxYeCt8=
 github.com/cyverse-de/go-mod/subjects v0.0.3 h1:kShf8J9IT+klXObIV7M6TAIy7TFa3vNlDy6kZAQm4ig=
@@ -122,6 +124,8 @@ github.com/cyverse-de/p/go/qms v0.0.12 h1:wdMDlyoZaKL5oLMRuBajKgva2VoKxOJQ8/820g
 github.com/cyverse-de/p/go/qms v0.0.12/go.mod h1:149A1Fx/vO7ovgEXaodYCLPvsX1squLb7u6MaSya3oM=
 github.com/cyverse-de/p/go/qms v0.0.19 h1:CkYr/M3vgOiZbCD1zhXPnAZn+911Btqbl1YPKXoIU3Y=
 github.com/cyverse-de/p/go/qms v0.0.19/go.mod h1:2zWzMlzjUeGWErAuovBkfD39rPFrqsbKOjl8tUy36I4=
+github.com/cyverse-de/p/go/qms v0.1.0 h1:nH9fdPx09tFqfNp8NKG+tCRcUYdNYKl1UO9xyul6/qk=
+github.com/cyverse-de/p/go/qms v0.1.0/go.mod h1:lDNWgFPsT0sg3fqHHEE2yhERNsfFueYJiprxtoOnp4c=
 github.com/cyverse-de/p/go/svcerror v0.0.5 h1:WbUcU4VjbNU0agfrHJOCy9orAY72WJWo92b1vR3+3sw=
 github.com/cyverse-de/p/go/svcerror v0.0.5/go.mod h1:WCGIrhW0KXtSu86YhjU/JXG8LrZs5wJPBCH4wvnFYcQ=
 github.com/cyverse-de/p/go/svcerror v0.0.7 h1:PScx8ctSBtnkER6ypgWsuxe8p3/jgfh6t/Dy5J9tg48=

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/cyverse-de/go-mod/subjects v0.0.3 h1:kShf8J9IT+klXObIV7M6TAIy7TFa3vNl
 github.com/cyverse-de/go-mod/subjects v0.0.3/go.mod h1:x8P+TNVSXvehkWMAmrg1RQHc5CCGafqtTKUn0hklkFA=
 github.com/cyverse-de/go-mod/subjects v0.0.6 h1:gQ3Rb2Tu7/kQMRCI1iSTyDB6yTHCUiZP8nDm3JyIJ4E=
 github.com/cyverse-de/go-mod/subjects v0.0.6/go.mod h1:x8P+TNVSXvehkWMAmrg1RQHc5CCGafqtTKUn0hklkFA=
+github.com/cyverse-de/go-mod/subjects v0.1.0 h1:ba9v19djad2a+p+TmQiDsl668p2XLt5fhNd24R2rpwU=
+github.com/cyverse-de/go-mod/subjects v0.1.0/go.mod h1:x8P+TNVSXvehkWMAmrg1RQHc5CCGafqtTKUn0hklkFA=
 github.com/cyverse-de/messaging/v9 v9.1.4 h1:DRMqWWT6nAGAnCk2Ajcikm13CJimttgQ5ClrvEA5UNw=
 github.com/cyverse-de/messaging/v9 v9.1.4/go.mod h1:bGZRCqilJTPBmWrgsyuupi3KRgkjQNs8yYNxZWZh8DI=
 github.com/cyverse-de/model/v6 v6.0.1 h1:6c0Tkl0hIbaJj7paI872QAPyvX9bhZNH93o37zDZG0s=

--- a/internal/summarizer/default.go
+++ b/internal/summarizer/default.go
@@ -98,7 +98,7 @@ func (d *DefaultSummarizer) LoadSummary() *UserSummary {
 	d.loadDataUsage(&summary)
 
 	// This resource usage summarizer leaves the subscription information blank.
-	summary.UserPlan = nil
+	summary.Subscription = nil
 
 	return &summary
 }

--- a/internal/summarizer/main.go
+++ b/internal/summarizer/main.go
@@ -23,10 +23,10 @@ func NewAPIError(field string, message string, errorCode int) *APIError {
 // UserSummary contains the data summarizing the user's current resource
 // usages and their current plan.
 type UserSummary struct {
-	CPUUsage  *db.CPUHours           `json:"cpu_usage"`
-	DataUsage *clients.UserDataUsage `json:"data_usage"`
-	UserPlan  *clients.UserPlan      `json:"user_plan"`
-	Errors    []APIError             `json:"errors"`
+	CPUUsage     *db.CPUHours           `json:"cpu_usage"`
+	DataUsage    *clients.UserDataUsage `json:"data_usage"`
+	Subscription *clients.Subscription  `json:"subscription"`
+	Errors       []APIError             `json:"errors"`
 }
 
 // The interface used to load the usage summary information.


### PR DESCRIPTION
This PR is part of the effort to rename the user_plans table in the QMS database to subscriptions. This includes changing all type names, references to user_plans in the SQL, and all NATS subjects containing references to user_plans or UserPlans.