### PR TITLE
Fix package-level log variable shadowing in handlers and set AMQP prefetch count

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   call-workflow-passing-data:
-    uses: cyverse-de/github-workflows/.github/workflows/golangci-lint.yml@v0.2.0
+    uses: cyverse-de/github-workflows/.github/workflows/golangci-lint.yml@v0.2.5
     with:
-      go-version: 1.24
+      go-version: 1.26

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+run:
+  timeout: 5m
+linters:
+  exclusions:
+    rules:
+      - linters:
+          - staticcheck 
+        text: "SA1019"

--- a/clients/data_usage_api.go
+++ b/clients/data_usage_api.go
@@ -64,7 +64,7 @@ func (c *DataUsageAPI) GetUsageSummary(ctx context.Context, username string) (*U
 	if err != nil {
 		return &usage, errors.Wrapf(err, "unable to send the request to %s", requestURL)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() // nolint: errcheck
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return &usage, NewHTTPError(resp.StatusCode, fmt.Sprintf("%s returned %d", requestURL, resp.StatusCode))
 	}

--- a/cpuhours/cpuhours.go
+++ b/cpuhours/cpuhours.go
@@ -48,22 +48,22 @@ func (c *CPUHours) CPUHoursForAnalysis(context context.Context, analysisID strin
 		err       error
 		res       CalculationResult
 	)
-	log = log.WithFields(logrus.Fields{"context": "calculating CPU hours", "analysisID": analysisID})
+	msgLog := log.WithFields(logrus.Fields{"context": "calculating CPU hours", "analysisID": analysisID})
 
-	log.Debug("getting millicores reserved")
+	msgLog.Debug("getting millicores reserved")
 	millicoresReserved, err := c.db.MillicoresReserved(context, analysisID)
 	if err != nil {
 		return res, err
 	}
-	log.Debug("done getting millicores reserved")
+	msgLog.Debug("done getting millicores reserved")
 
 	for i := 0; i < 5; i++ { // Try five times, then use time.Now().UTC() instead
-		log.Debug("getting analysis info and locking row")
+		msgLog.Debug("getting analysis info and locking row")
 		analysis, err = c.db.AnalysisWithoutUser(context, analysisID)
 		if err != nil {
 			return res, err
 		}
-		log.Debug("done getting analysis info")
+		msgLog.Debug("done getting analysis info")
 
 		if !analysis.StartDate.Valid {
 			return res, fmt.Errorf("start date is null")
@@ -76,7 +76,7 @@ func (c *CPUHours) CPUHoursForAnalysis(context context.Context, analysisID strin
 		// issues and allow the end date to get set by other processes
 		if !analysis.EndDate.Valid {
 			if err := c.db.Rollback(); err != nil {
-				log.WithError(err).Error("failed to rollback transaction")
+				msgLog.WithError(err).Error("failed to rollback transaction")
 			}
 			time.Sleep(5 * time.Second)
 			c.db.Begin(context) // nolint: errcheck
@@ -105,7 +105,7 @@ func (c *CPUHours) CPUHoursForAnalysis(context context.Context, analysisID strin
 
 	res.BasisTime = basisTime
 	res.CalcTime = calcTime
-	log.Infof("basis date: %s, end date: %s", basisTime.String(), calcTime.String())
+	msgLog.Infof("basis date: %s, end date: %s", basisTime.String(), calcTime.String())
 
 	timeSpent, err := apd.New(0, 0).SetFloat64(calcTime.Sub(basisTime).Hours())
 	if err != nil {
@@ -127,7 +127,7 @@ func (c *CPUHours) CPUHoursForAnalysis(context context.Context, analysisID strin
 		return res, err
 	}
 
-	log.Infof("run time is %s hours; millicores reserved is %s; cpu hours is %s", timeSpent.String(), mcReserved.String(), cpuHours.String())
+	msgLog.Infof("run time is %s hours; millicores reserved is %s; cpu hours is %s", timeSpent.String(), mcReserved.String(), cpuHours.String())
 
 	err = c.db.SetUsageLastUpdate(context, analysisID, calcTime)
 	if err != nil {
@@ -181,14 +181,14 @@ func (c *CPUHours) addEvent(context context.Context, res CalculationResult) erro
 	_, span := pbinit.InitQMSAddUpdateRequest(request, subjects.QMSAddUserUpdate)
 	defer span.End()
 
-	log = log.WithFields(logrus.Fields{"context": "adding event", "analysisID": analysis.ID})
+	msgLog := log.WithFields(logrus.Fields{"context": "adding event", "analysisID": analysis.ID})
 
-	log.Debug("adding cpu usage event", request)
+	msgLog.Debug("adding cpu usage event", request)
 	if err = gotelnats.Request(context, c.nc, subjects.QMSAddUserUpdate, request, response); err != nil {
-		log.WithError(err).Error("Failed to add CPU usage event", response)
+		msgLog.WithError(err).Error("Failed to add CPU usage event", response)
 		return err
 	}
-	log.Debug("after add cpu usage event")
+	msgLog.Debug("after add cpu usage event")
 
 	return nil
 }

--- a/internal/summarizer/httpsummarizer.go
+++ b/internal/summarizer/httpsummarizer.go
@@ -49,7 +49,7 @@ func (h *HTTPSummarizer) LoadSummary() *UserSummary {
 		log.Error(err)
 		return &summary
 	}
-	defer httpResp.Body.Close()
+	defer httpResp.Body.Close() // nolint: errcheck
 
 	b, err := io.ReadAll(httpResp.Body)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -40,17 +40,17 @@ func getHandler(dbClient *sqlx.DB, nc *nats.EncodedConn) amqp.HandlerFn {
 	return func(context context.Context, externalID string, state messaging.JobState) {
 		var err error
 
-		log = log.WithFields(logrus.Fields{"externalID": externalID}).WithContext(context)
+		msgLog := log.WithFields(logrus.Fields{"externalID": externalID}).WithContext(context)
 
 		// TODO: should this happen for non-failed/succeeded messages?
 		if state == messaging.FailedState || state == messaging.SucceededState {
-			log.Debug("calculating CPU hours for analysis")
+			msgLog.Debug("calculating CPU hours for analysis")
 			if err = cpuhours.CalculateForAnalysis(context, externalID); err != nil {
-				log.Error(err)
+				msgLog.Error(err)
 			}
-			log.Debug("done calculating CPU hours for analysis")
+			msgLog.Debug("done calculating CPU hours for analysis")
 		} else {
-			log.Debugf("received status is %s, ignoring", state)
+			msgLog.Debugf("received status is %s, ignoring", state)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 	nats.RegisterEncoder("protojson", protobufjson.NewCodec(protobufjson.WithEmitUnpopulated()))
 
 	log.Infof("config path is %s", *configPath)
-	log.Infof("listen port is %d", listenPort)
+	log.Infof("listen port is %d", *listenPort)
 	log.Infof("NATS TLS cert file is %s", *tlsCert)
 	log.Infof("NATS TLS key file is %s", *tlsKey)
 	log.Infof("NATS CA cert file is %s", *caCert)
@@ -192,7 +192,7 @@ func main() {
 		ExchangeType:  amqpExchangeType,
 		Reconnect:     *reconnect,
 		Queue:         *queue,
-		PrefetchCount: 0,
+		PrefetchCount: 10,
 	}
 
 	log.Infof("AMQP exchange name: %s", amqpConfig.Exchange)


### PR DESCRIPTION
Two small fixes from a branch I forgot I was working on back in March/April:

1. Replace log = log.WithFields(...) with local msgLog := log.WithFields(...) in four places across main.go and cpuhours/cpuhours.go to avoid mutating the package-level logger, which could cause nil-pointer dereferences and data races when handlers run concurrently.
2. Change AMQP PrefetchCount from 0 (unlimited) to 10, preventing RabbitMQ from dumping all messages on a consumer at once, which improves memory usage and load distribution.